### PR TITLE
Changed Raycast to newer version.

### DIFF
--- a/src/Types/ProjectileConfig.ts
+++ b/src/Types/ProjectileConfig.ts
@@ -61,6 +61,8 @@ export type ProjectileConfig = {
 	 */
 	physicsIgnore?: Array<Instance>;
 
+	raycastParams?: RaycastParams;
+
 	/**
 	 * The amount of resistance applied during a penetration
 	 * Defaults to 1


### PR DESCRIPTION
The previous package uses Workspace.FindPartOnRayWithIgnoreList(), which was deprecated, and with the recent performance optimization of Workspace.Raycast, I tried my best to implement that here.

Note: I'm not sure if this is the most efficient way of doing so, but this is my attempt.